### PR TITLE
[BACK-593] Include direct IP list download from Bright Data

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,18 +10,26 @@ if [[ -z "${PROXY_LIST_URL}" ]]; then
     echo "Using mounted proxy list"
     touch $BASE_DIR/proxy-list.txt
     echo " ---> Done"
-else
+elif [[ -z "${BRIGHT_DATA_API_TOKEN}"]]; then
     echo "Downloading proxy list from $PROXY_LIST_URL"
     curl -s $PROXY_LIST_URL > $BASE_DIR/proxy-list.txt
     echo " ---> Done"
+else
+    echo "Downloading proxy list from $PROXY_LIST_URL"
+    curl -s -H "Authorization: Bearer $BRIGHT_DATA_API_TOKEN" "$PROXY_LIST_URL" > $BASE_DIR/proxy-list.txt
+    echo "Correctly formatting proxy list file"
+    # Builds the URL with the username, password and the endpoint of Bright Data
+    SUBSTITUTION_PATTERN="s/^.*/http:\/\/${BRIGHT_DATA_USERNAME}-ip-&:${BRIGHT_DATA_PASSWORD}@brd.superproxy.io:22225/"
+    sed -i $SUBSTITUTION_PATTERN $BASE_DIR/proxy-list.txt
+    echo " ---> Done"
 fi
 
-echo "Adding proy list to config file"
+echo "Adding proxy list to config file"
 # Remove blank lines
 sed -i '/^$/d' $BASE_DIR/proxy-list.txt
 # Prepend forward= in front of each line to match glider config syntax
 sed -i 's/^/forward=/' $BASE_DIR/proxy-list.txt
-# Randomize and happen 
+# Randomize and append
 cat $BASE_DIR/proxy-list.txt | shuf >> $BASE_DIR/glider.conf
 echo " ---> Done"
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,21 +6,22 @@ if [[ -z "${BASE_DIR}" ]]; then
     BASE_DIR="/app"
 fi
 
-if [[ -z "${PROXY_LIST_URL}" ]]; then
-    echo "Using mounted proxy list"
-    touch $BASE_DIR/proxy-list.txt
-    echo " ---> Done"
-elif [[ -z "${BRIGHT_DATA_API_TOKEN}"]]; then
-    echo "Downloading proxy list from $PROXY_LIST_URL"
-    curl -s $PROXY_LIST_URL > $BASE_DIR/proxy-list.txt
-    echo " ---> Done"
-else
-    echo "Downloading proxy list from $PROXY_LIST_URL"
-    curl -s -H "Authorization: Bearer $BRIGHT_DATA_API_TOKEN" "$PROXY_LIST_URL" > $BASE_DIR/proxy-list.txt
+if [[ -n "${BRIGHT_DATA_API_TOKEN}" && -n "${BRIGHT_DATA_USERNAME}" && -n "${BRIGHT_DATA_PASSWORD}" && -n "${BRIGHT_DATA_ZONE}" ]]; then
+    BRIGHT_DATA_URL="https://api.brightdata.com/zone/route_ips?zone=$BRIGHT_DATA_ZONE"
+    echo "Downloading proxy list from $BRIGHT_DATA_URL"
+    curl -s -H "Authorization: Bearer $BRIGHT_DATA_API_TOKEN" "$BRIGHT_DATA_URL" > $BASE_DIR/proxy-list.txt
     echo "Correctly formatting proxy list file"
     # Builds the URL with the username, password and the endpoint of Bright Data
     SUBSTITUTION_PATTERN="s/^.*/http:\/\/${BRIGHT_DATA_USERNAME}-ip-&:${BRIGHT_DATA_PASSWORD}@brd.superproxy.io:22225/"
     sed -i $SUBSTITUTION_PATTERN $BASE_DIR/proxy-list.txt
+    echo " ---> Done"
+elif [[ -z "${PROXY_LIST_URL}" ]]; then
+    echo "Using mounted proxy list"
+    touch $BASE_DIR/proxy-list.txt
+    echo " ---> Done"
+else
+    echo "Downloading proxy list from $PROXY_LIST_URL"
+    curl -s $PROXY_LIST_URL > $BASE_DIR/proxy-list.txt
     echo " ---> Done"
 fi
 


### PR DESCRIPTION
## What does this PR do?
Include the possibility to download the IP list directly from Bright Data through their API. This requires a new set of environment variables, including the api token, the username and password for the proxy (for the specific zone).

I don't remove the previous behavior, so we need to pass the Bright Data url `https://api.brightdata.com/zone/route_ips?zone=ZONE` as described in [the documentation](https://help.brightdata.com/hc/en-us/articles/4419693814673-Get-the-available-Data-center-ISP-IPs-per-Zone).

## Associated ticket number and/or AirBrake error?
[BACK-593]

## Due Date or Desirable Merge
I still need to finish the setup of the new zones, but will probably need this by early next week.

## How has this been tested?
I ran the script locally to make sure that it's working as expected.

## Anticipated impact
Shouldn't change current behavior unless the new variables are set.

## How do you plan to monitor the change in prod to make sure it's working?
This will either work or fail miserably when deploying the proxy rotators.. will be easy to see.

## Checklist
- [x] My code follows the code style of this project.
- [x] I have run tests locally (manual tests and otherwise).
- [ ] This has been tested on staging.
- [x] My changes require changes in other components/squads/teams
  - [ ] I already did the changes in the other components or notified the responsible people that the changes need to be done
  - [ ] The needed changes are already deployed or ready to be deployed


[BACK-593]: https://apptweak.atlassian.net/browse/BACK-593?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ