### PR TITLE
update BrightData port from 22225 to 44445

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,7 +12,7 @@ if [[ -n "${BRIGHT_DATA_API_TOKEN}" && -n "${BRIGHT_DATA_USERNAME}" && -n "${BRI
     curl -s -H "Authorization: Bearer $BRIGHT_DATA_API_TOKEN" "$BRIGHT_DATA_URL" > $BASE_DIR/proxy-list.txt
     echo "Correctly formatting proxy list file"
     # Builds the URL with the username, password and the endpoint of Bright Data
-    SUBSTITUTION_PATTERN="s/^.*/http:\/\/${BRIGHT_DATA_USERNAME}-ip-&:${BRIGHT_DATA_PASSWORD}@brd.superproxy.io:22225/"
+    SUBSTITUTION_PATTERN="s/^.*/http:\/\/${BRIGHT_DATA_USERNAME}-ip-&:${BRIGHT_DATA_PASSWORD}@brd.superproxy.io:44445/"
     sed -i $SUBSTITUTION_PATTERN $BASE_DIR/proxy-list.txt
     echo " ---> Done"
 elif [[ -z "${PROXY_LIST_URL}" ]]; then


### PR DESCRIPTION
## What does this PR do?
BrightData port needs to be updated from `22225` to `44445`

## Associated ticket number and/or AirBrake error?
See https://docs.brightdata.com/general/account/ssl-certificate#download-the-ssl-certificate for more information and more specifically:

<img width="739" height="118" alt="image" src="https://github.com/user-attachments/assets/80d9e570-06ab-4601-9692-f3e6cdadbca3" />

## Due Date or Desirable Merge
Before the 25th of September

## How has this been tested?
N/A

## Anticipated impact
No anticipated impact

## How do you plan to monitor the change in prod to make sure it's working?
Airbrake

## Checklist
- [x] My code follows the code style of this project.
- [x] I have run tests locally (manual tests and otherwise).
- [ ] This has been tested on staging.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] My change includes a database modification
  - [ ] I have tested my database modification in staging.
- [ ] My change breaks API retrocompatibility.
  - [ ] I have notified the frontend developers concerned about this change.
  - [ ] I have notified the public API consumers about this change. (DataPi)
- [ ] My change touches on some of the following areas: **authorizing access to integration data** (consoles, search ads, MMP), **authentication** (including serving or consuming OAuth endpoints), **cryptography and security** (including generation of secure tokens). If so:
  - [ ] I am tagging a senior reviewer to specifically review the security of this change: (flag reviewer here)
- [ ] My changes require changes in other components/squads/teams
  - [ ] I already did the changes in the other components or notified the responsible people that the changes need to be done
  - [ ] The needed changes are already deployed or ready to be deployed
